### PR TITLE
Specify bookworm in build script

### DIFF
--- a/scripts/debootstrap.sh
+++ b/scripts/debootstrap.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 CHROOT=${CHROOT=$(pwd)/rootfs}
-RELEASE=${RELEASE=stable}
+RELEASE=${RELEASE=bookworm}
 HOST_NAME=${HOST_NAME=openstick}
 
 rm -rf ${CHROOT}


### PR DESCRIPTION
Debian 13 is now stable, and building from this script will make further apt updates switch to trixie repository. Not all bugs are worked out if this happens. (I may be off-base, but upgrading broke networking on my stick)